### PR TITLE
fix: Disable sourceMap to be able to use the library without warnings

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
         "module": "commonjs",
         "target": "es5",
         "lib": ["esnext"],
-        "sourceMap": true,
+        "sourceMap": false,
         "allowJs": false,
         "jsx": "preserve",
         "moduleResolution": "node",


### PR DESCRIPTION
The build does not bundle "src" into the distribution package. This will cause e.g. webpack bundled with react-scripts 5 to print lots of warnings about having source maps without the src files.

Disable sourceMap to fix #443 