### PR TITLE
Add prepack script to build and test the package before publishing it

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "test": "jest --verbose"
+    "test": "jest --verbose",
+    "prepack": "npm ci && npm run build && npm run test"
   },
   "keywords": [
     "Emotion",


### PR DESCRIPTION
Adding this line makes sure the `dist` folder exists and the tests succeed before publishing.

Fixes #447